### PR TITLE
Fix localization; fix creating weekly notes for notes in other months

### DIFF
--- a/src/localization.ts
+++ b/src/localization.ts
@@ -1,0 +1,34 @@
+const langToMomentLocale = {
+  en: null,
+  zh: "zh-cn",
+  "zh-TW": "zh-tw",
+  ru: "ru",
+  ko: "ko",
+  it: "it",
+  id: "id",
+  ro: "ro",
+  "pt-BR": "pt-br",
+  cz: "cs",
+  de: "de",
+  es: "es",
+  fr: "fr",
+  no: "nn",
+  pl: "pl",
+  pt: "pt",
+  tr: "tr",
+  hi: "hi",
+  nl: "nl",
+  ar: "ar",
+  ja: "ja",
+};
+
+export async function configureMomentLocale(): Promise<void> {
+  const obsidianLang = localStorage.getItem("language");
+  const systemLang = navigator.language?.toLowerCase();
+  const momentLocale = langToMomentLocale[obsidianLang] || systemLang;
+
+  const currentLocale = window.moment.locale(momentLocale);
+  console.info(
+    `Calendar initialization: Trying to switch Moment.js global locale to ${momentLocale}, got ${currentLocale}`
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import type { Moment, WeekSpec } from "moment";
 import { App, Plugin, WorkspaceLeaf } from "obsidian";
 
+import { configureMomentLocale } from "src/localization";
+
 import { VIEW_TYPE_CALENDAR } from "./constants";
 import {
   CalendarSettingsTab,
@@ -16,15 +18,6 @@ declare global {
     moment: () => Moment;
     _bundledLocaleWeekSpec: WeekSpec;
   }
-}
-
-function configureMomentLocale(): void {
-  const lang = localStorage.getItem("language");
-
-  const currentLocale = window.moment.locale(lang);
-  console.info(
-    `trying to switch moment locale to ${lang}, got ${currentLocale}`
-  );
 }
 
 export default class CalendarPlugin extends Plugin {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,13 +9,12 @@ import {
   IDailyNoteSettings,
 } from "obsidian-daily-notes-interface";
 
-type IWeekStartOptions = "locale" | "sunday" | "monday";
+type IWeekStartOption = "sunday" | "monday" | "locale";
 
 export interface ISettings {
-  weekStart: IWeekStartOptions;
-  shouldConfirmBeforeCreate: boolean;
-
   wordsPerDot: number;
+  weekStart: IWeekStartOption;
+  shouldConfirmBeforeCreate: boolean;
 
   // Weekly Note settings
   showWeeklyNote: boolean;
@@ -128,19 +127,23 @@ export class CalendarSettingsTab extends PluginSettingTab {
 
     const [sunday, monday] = moment.weekdays();
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const localeWeekStartNum = (<any>moment.localeData())._week.dow;
+    const localeWeekStart = moment.weekdays()[localeWeekStartNum];
+
     new Setting(this.containerEl)
       .setName("Start week on:")
       .setDesc(
         "Choose what day of the week to start. Select 'Locale default' to use the default specified by moment.js"
       )
       .addDropdown((dropdown) => {
-        dropdown.addOption("locale", "Locale default");
+        dropdown.addOption("locale", `Locale default (${localeWeekStart})`);
         dropdown.addOption("sunday", sunday);
         dropdown.addOption("monday", monday);
         dropdown.setValue(this.plugin.options.weekStart);
         dropdown.onChange(async (value) => {
           this.plugin.writeOptions(
-            (old) => (old.weekStart = value as IWeekStartOptions)
+            (old) => (old.weekStart = value as IWeekStartOption)
           );
         });
       });

--- a/src/ui/WeekNum.svelte
+++ b/src/ui/WeekNum.svelte
@@ -7,6 +7,7 @@
   import {
     getNumberOfDots,
     getNumberOfRemainingTasks,
+    getStartOfWeek,
     IDay,
     isMetaPressed,
   } from "./utils";
@@ -29,13 +30,15 @@
     inNewSplit: boolean
   ) => void;
 
+  const { format } = getWeeklyNoteSettings(settings);
+
+  let startOfWeek: Moment;
+  let formattedDate: string;
   let isActive: boolean;
 
-  const startOfWeek = days[0].date.weekday(0);
-  const { format } = getWeeklyNoteSettings(settings);
-  const formattedDate = startOfWeek.format(format);
-
   $: isActive = activeFile && weeklyNote?.basename === activeFile;
+  $: startOfWeek = getStartOfWeek(days, weekNum);
+  $: formattedDate = startOfWeek.format(format);
 </script>
 
 <style>

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -75,6 +75,10 @@ export function isWeekend(date: Moment): boolean {
   return date.isoWeekday() === 6 || date.isoWeekday() === 7;
 }
 
+export function getStartOfWeek(days: IDay[], _weekNum: number): Moment {
+  return days[0].date.weekday(0);
+}
+
 /**
  * Generate a 2D array of daily information to power
  * the calendar view.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,9 +3328,8 @@ obsidian-daily-notes-interface@0.2.2:
     obsidian obsidianmd/obsidian-api#master
     tslib "2.0.3"
 
-"obsidian@github:obsidianmd/obsidian-api#master", obsidian@obsidianmd/obsidian-api#master:
+obsidian@obsidianmd/obsidian-api#master:
   version "0.9.16"
-  uid "3efab21fc0cfef3ae75951beb66aadd479ae610d"
   resolved "https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/3efab21fc0cfef3ae75951beb66aadd479ae610d"
   dependencies:
     "@types/codemirror" "0.0.98"


### PR DESCRIPTION
Localization fixes:
- There is now a 1:1 mapping of Obsidian languages to moment locales for better language support
-  Use the locale of the OS to disambiguate between `en-US` and `en-GB`. This should fix the week numbering as well and correctly default weeks starting on Monday.