### PR TITLE
Fix/better weekly note handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "calendar",
   "name": "Calendar",
   "description": "Calendar view of your daily notes",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "author": "Liam Cain",
   "authorUrl": "https://github.com/liamcain/",
   "isDesktopOnly": false,

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "obsidian": "obsidianmd/obsidian-api#master",
-    "obsidian-calendar-ui": "0.3.4",
-    "obsidian-daily-notes-interface": "0.7.3",
-    "svelte": "3.32.3",
+    "obsidian-calendar-ui": "0.3.5",
+    "obsidian-daily-notes-interface": "0.7.6",
+    "svelte": "3.35.0",
     "tslib": "2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Calendar view of your daily notes",
   "author": "liamcain",
   "main": "main.js",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -44,7 +44,7 @@ export const defaultSettings = Object.freeze({
   localeOverride: "system-default",
 });
 
-export function appHasPeriodicNotesPluginLoaded() {
+export function appHasPeriodicNotesPluginLoaded(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const periodicNotes = (<any>window.app).plugins.getPlugin("periodic-notes");
   return periodicNotes && periodicNotes.settings?.weekly?.enabled;

--- a/src/ui/fileMenu.ts
+++ b/src/ui/fileMenu.ts
@@ -8,7 +8,7 @@ export function showFileMenu(app: App, file: TFile, position: Point): void {
       .setIcon("trash")
       .onClick(() => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (<any>app).fileManager.promptForFolderDeletion(file);
+        (<any>app).fileManager.promptForFileDeletion(file);
       })
   );
 

--- a/src/ui/stores.ts
+++ b/src/ui/stores.ts
@@ -38,7 +38,6 @@ function createWeeklyNotesStore() {
     reindex: () => {
       try {
         const weeklyNotes = getAllWeeklyNotes();
-        console.log("weekly", weeklyNotes);
         store.set(weeklyNotes);
         hasError = false;
       } catch (err) {

--- a/src/ui/stores.ts
+++ b/src/ui/stores.ts
@@ -38,6 +38,7 @@ function createWeeklyNotesStore() {
     reindex: () => {
       try {
         const weeklyNotes = getAllWeeklyNotes();
+        console.log("weekly", weeklyNotes);
         store.set(weeklyNotes);
         hasError = false;
       } catch (err) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -300,10 +300,12 @@ export default class CalendarView extends ItemView {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mode = (this.app.vault as any).getConfig("defaultViewMode");
     const leaf = inNewSplit
       ? workspace.splitActiveLeaf()
       : workspace.getUnpinnedLeaf();
-    await leaf.openFile(existingFile);
+    await leaf.openFile(existingFile, { mode });
 
     activeFile.setFile(existingFile);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,22 +3308,22 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-obsidian-calendar-ui@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.4.tgz#7115e3ab53d308a28720b54e548a1c9975e7b134"
-  integrity sha512-6tMLO+weEJUz6AIsPuAT05ktXkgrMwqASDLWbuJYn8TwRqYbMlHC85UybonsDk+TC4zlXFyfXEBBOgHCPAHgzw==
+obsidian-calendar-ui@0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.5.tgz#d4a9090d828e7f8f05189567bfc4a942fea4e288"
+  integrity sha512-+zO7cqr2qA0f7vfIL680YexztVbERQLv3axRJ+HsjdveaelJVQDNXH0sJcfQrMfOZuGZgHpN48fFEr9R2reeQg==
   dependencies:
-    obsidian-daily-notes-interface "0.7.3"
-    svelte "3.32.3"
+    obsidian-daily-notes-interface "0.7.6"
+    svelte "3.35.0"
     tslib "2.1.0"
 
-obsidian-daily-notes-interface@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.7.3.tgz#48b8917f23aa2534cf4516246a793f44a2e119e8"
-  integrity sha512-SbaguZ9+qPjiX/VAxONls78ji2hEMALTR3bqmifzLtZf+xUOf7jMvtCsGK7KG4zDMLlpkPT/RnbCenXKvWnbVA==
+obsidian-daily-notes-interface@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.7.6.tgz#2161cff49ddcdcf14aafce5fc660c4efe1d73b4a"
+  integrity sha512-b9MITVljqYZlbvTbhFZ3td/Nmmg9sFaGCn7QGNRj0XPrPhOUUt6iPKJqjfPPstNtqRgc1ufUZdRXxlsJu0grWQ==
   dependencies:
     obsidian obsidianmd/obsidian-api#master
-    tslib "2.0.3"
+    tslib "2.1.0"
 
 "obsidian@github:obsidianmd/obsidian-api#master":
   version "0.11.0"
@@ -4157,10 +4157,10 @@ svelte-preprocess@^4.0.0:
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
 
-svelte@3.32.3:
-  version "3.32.3"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.32.3.tgz#db0c50c65573ecffe4e2f4924e4862d8f9feda74"
-  integrity sha512-5etu/wDwtewhnYO/631KKTjSmFrKohFLWNm1sWErVHXqGZ8eJLqrW0qivDSyYTcN8GbUqsR4LkIhftNFsjNehg==
+svelte@3.35.0:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.35.0.tgz#e0d0ba60c4852181c2b4fd851194be6fda493e65"
+  integrity sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -4286,11 +4286,6 @@ ts-jest@26.5.1:
     mkdirp "1.x"
     semver "7.x"
     yargs-parser "20.x"
-
-tslib@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tslib@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
- Fixes #150 - You can now delete notes from the right-click menu again
- Fixes #147 - Opening notes from the calendar respects your default view mode
- Fixes parsing of certain ambiguous weekly note formats (e.g. formats that contain both `DD` and `ww`)
