### PR TITLE
[FEAT] Add support for "math" in templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Calendar view of your daily notes",
   "author": "liamcain",
   "main": "main.js",
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "obsidian": "obsidianmd/obsidian-api#master",
-    "obsidian-calendar-ui": "0.3.10",
-    "obsidian-daily-notes-interface": "0.7.10",
+    "obsidian-calendar-ui": "0.3.11",
+    "obsidian-daily-notes-interface": "0.8.2",
     "svelte": "3.35.0",
     "tslib": "2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,9 +658,9 @@
     "@types/tern" "*"
 
 "@types/estree@*":
-  version "0.0.46"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
-  integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -3319,24 +3319,24 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-obsidian-calendar-ui@0.3.10:
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.10.tgz#95a2ef56c88be2ba094f04bce44186df0b40c3bd"
-  integrity sha512-533grPPG131ZB7/ns99+zYhXyP02l/5LzZ6Xi9Eh80ohCXqy6KO8Lj7RR7HNGI7dGgAAOHw9i8xFLsfT1fWZXg==
+obsidian-calendar-ui@0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/obsidian-calendar-ui/-/obsidian-calendar-ui-0.3.11.tgz#d8425b55d4d1645bb77c52bac01d04451bdf99f0"
+  integrity sha512-6/Fd99UZJ7ay1j58qnwzyFo9DyxIXW8w/CwOTNIzCZ/mvQO/uDgFLxjjQBejBtcjFuG15CvwSDAxaTqAUI/nLw==
   dependencies:
-    obsidian-daily-notes-interface "0.7.10"
+    obsidian-daily-notes-interface "0.8.2"
     svelte "3.35.0"
     tslib "2.1.0"
 
-obsidian-daily-notes-interface@0.7.10:
-  version "0.7.10"
-  resolved "https://registry.yarnpkg.com/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.7.10.tgz#38b65845408bd2a597227f991e8e8a46833d1922"
-  integrity sha512-9FzyAmWAki0rWS4dWHbwXatcVbWcZWT/vJEoat56Ozf3WN0xY6Pe+xdy3jwjwN8QyxK9Xxb0MJ/ARN/rN4ZNZg==
+obsidian-daily-notes-interface@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/obsidian-daily-notes-interface/-/obsidian-daily-notes-interface-0.8.2.tgz#5445743acee00f7767e555769da9ec40593a1dbb"
+  integrity sha512-r9AwcD8pTFx6/u6ZeSHHlOpLRDS34oql4sE3N8gKxKMPhsupQskfXd6fYIUcb3Fgp2c7/1q3SUOl1xFTRxq/BQ==
   dependencies:
     obsidian obsidianmd/obsidian-api#master
     tslib "2.1.0"
 
-"obsidian@github:obsidianmd/obsidian-api#master", obsidian@obsidianmd/obsidian-api#master:
+obsidian@obsidianmd/obsidian-api#master:
   version "0.11.7"
   resolved "https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/55946e5a6259a28c416d2d6e600a7964a86a01dd"
   dependencies:


### PR DESCRIPTION
Add support for calculating the date. Examples:

```
{{yesterday}}
{{tomorrow}}
{{date-1d:YYYY-MM-DD}} // yesterday
{{date+2d:YYYY-MM-DD}} // in two days
{{date+1M:YYYY-MM-DD}} // next month
{{date+10y:YYYY-MM-DD}} // in 10 years
{{date +7d}} // use default format
```

Supported units:
|Unit|Shorthand|
|--|--|
years | y
quarters | Q
months | M
weeks | w
days | d
hours | h
minutes | m
seconds | s
