### PR TITLE
accept normal tags

### DIFF
--- a/src/ui/sources/tags.ts
+++ b/src/ui/sources/tags.ts
@@ -13,12 +13,14 @@ function getNoteTags(note: TFile | null): string[] {
     return [];
   }
 
-  const { metadataCache } = window.app;
-  const frontmatter = metadataCache.getFileCache(note)?.frontmatter;
+  const fileCache = window.app.metadataCache.getFileCache(note);
+  const frontmatter = fileCache?.frontmatter;
 
-  const tags = [];
+  // get normal tags
+  const tags = fileCache?.tags?.map((it) => it.tag) || [];
 
   if (frontmatter) {
+    // get metadata tags
     const frontmatterTags = parseFrontMatterTags(frontmatter) || [];
     tags.push(...frontmatterTags);
   }


### PR DESCRIPTION
Personally, I prefer to use default syntax for tags instead of YAML metadata. This PR allows to use in-note tags alongside with metadata tags for css customization.