### PR TITLE
Add option to put week numbers on either side of calendar

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export interface ISettings {
 
   // Weekly Note settings
   showWeeklyNote: boolean;
+  showWeeklyNoteRight: boolean;
   weeklyNoteFormat: string;
   weeklyNoteTemplate: string;
   weeklyNoteFolder: string;
@@ -37,6 +38,7 @@ export const defaultSettings = Object.freeze({
   wordsPerDot: DEFAULT_WORDS_PER_DOT,
 
   showWeeklyNote: false,
+  showWeeklyNoteRight: false,
   weeklyNoteFormat: "",
   weeklyNoteTemplate: "",
   weeklyNoteFolder: "",
@@ -81,6 +83,7 @@ export class CalendarSettingsTab extends PluginSettingTab {
     this.addWeekStartSetting();
     this.addConfirmCreateSetting();
     this.addShowWeeklyNoteSetting();
+    this.addShowWeeklyNoteRightSetting();
 
     if (
       this.plugin.options.showWeeklyNote &&
@@ -172,6 +175,19 @@ export class CalendarSettingsTab extends PluginSettingTab {
           this.display(); // show/hide weekly settings
         });
       });
+  }
+
+  addShowWeeklyNoteRightSetting(): void {
+    new Setting(this.containerEl)
+        .setName("Change week number side")
+        .setDesc("Enable this to show week numbers to the right of the calendar")
+        .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.showWeeklyNoteRight);
+          toggle.onChange(async (value) => {
+            this.plugin.writeOptions(() => ({ showWeeklyNoteRight: value }));
+            this.display(); // show/hide weekly settings
+          });
+        });
   }
 
   addWeeklyNoteFormatSetting(): void {

--- a/src/testUtils/settings.ts
+++ b/src/testUtils/settings.ts
@@ -10,6 +10,7 @@ export function getDefaultSettings(
       shouldConfirmBeforeCreate: false,
       wordsPerDot: 50,
       showWeeklyNote: false,
+      showWeeklyNoteRight: false,
       weeklyNoteFolder: "",
       weeklyNoteFormat: "",
       weeklyNoteTemplate: "",

--- a/src/ui/Calendar.svelte
+++ b/src/ui/Calendar.svelte
@@ -66,4 +66,5 @@
   localeData={today.localeData()}
   selectedId={$activeFile}
   showWeekNums={$settings.showWeeklyNote}
+  showWeekNumsRight={$settings.showWeeklyNoteRight}
 />


### PR DESCRIPTION
Adds a new parameter that instructs the base calendar component to show the week number column (when enabled) on either the left or right side of the calendar.

Dependent on a feature of the UI introduced in https://github.com/liamcain/obsidian-calendar-ui/pull/17.