### PR TITLE
Fix word count for non-space-delimited characters

### DIFF
--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -66,7 +66,7 @@ export function getWordCount(text: string): number {
   const pattern = new RegExp(
     [
       `(?:[0-9]+(?:(?:,|\\.)[0-9]+)*|[\\-${spaceDelimitedChars}])+`,
-      nonSpaceDelimitedWords,
+      `[${nonSpaceDelimitedWords}]`,
     ].join("|"),
     "g"
   );


### PR DESCRIPTION
The current implementation has a bug in the regexp which actually does not count any non-space-delimited characters at all.
