### PR TITLE
Add view mode override for new calendar notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The plugin reads your Daily Note settings to know your date format, your daily n
 - **Start week on [default: locale]**: Configure the Calendar view to show Sunday or Monday as the first day of the week. Choosing 'locale' will set the start day to be whatever is the default for your chosen locale (`Settings > About > Language`)
 - **Words per Dot [default: 250]**: Starting in version 1.3, dots reflect the word count of your files. By default, each dot represents 250 words, you can change that value to whatever you want. Set this to `0` to disable the word count entirely. **Note:** There is a max of 5 dots so that the view doesn't get too big!
 - **Confirm before creating new note [default: on]**: If you don't like that a modal prompts you before creating a new daily note, you can turn it off.
+- **Override default view for new notes [default: off]**: If you want new daily notes created by clicking on the calendar to be in a different mode than Obsidian's default for new notes, then enable this override.
 - **Show Week Number [default: off]**: Enable this to add a new column to the calendar view showing the [Week Number](https://en.wikipedia.org/wiki/Week#Week_numbering). Clicking on these cells will open your **weekly note**.
 
 ## Customization

--- a/src/io/dailyNotes.ts
+++ b/src/io/dailyNotes.ts
@@ -26,8 +26,10 @@ export async function tryToCreateDailyNote(
     const leaf = inNewSplit
       ? workspace.splitActiveLeaf()
       : workspace.getUnpinnedLeaf();
-
-    await leaf.openFile(dailyNote, { active : true });
+    const openState = settings.enableViewModeOverride
+      ? { active : true, state : { mode : settings.viewModeOverride } }
+      : { active : true };
+    await leaf.openFile(dailyNote, openState);
     cb?.(dailyNote);
   };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,8 @@ export interface ISettings {
   wordsPerDot: number;
   weekStart: IWeekStartOption;
   shouldConfirmBeforeCreate: boolean;
+  enableViewModeOverride: boolean,
+  viewModeOverride: string;
 
   // Weekly Note settings
   showWeeklyNote: boolean;
@@ -33,6 +35,8 @@ const weekdays = [
 export const defaultSettings = Object.freeze({
   shouldConfirmBeforeCreate: true,
   weekStart: "locale" as IWeekStartOption,
+  enableViewModeOverride: false,
+  viewModeOverride: app.vault.getConfig("defaultViewMode"),
 
   wordsPerDot: DEFAULT_WORDS_PER_DOT,
 
@@ -80,6 +84,7 @@ export class CalendarSettingsTab extends PluginSettingTab {
     this.addDotThresholdSetting();
     this.addWeekStartSetting();
     this.addConfirmCreateSetting();
+    this.addViewModeOverrideSetting();
     this.addShowWeeklyNoteSetting();
 
     if (
@@ -156,6 +161,40 @@ export class CalendarSettingsTab extends PluginSettingTab {
         toggle.onChange(async (value) => {
           this.plugin.writeOptions(() => ({
             shouldConfirmBeforeCreate: value,
+          }));
+        });
+      });
+  }
+
+  addViewModeOverrideSetting(): void {
+    new Setting(this.containerEl)
+      .setName("Override default view for new notes")
+      .setDesc("Override the default view for new notes created via the calendar")
+      .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.enableViewModeOverride);
+          toggle.onChange(async (value) => {
+                  this.plugin.writeOptions(() => ({
+                    enableViewModeOverride: value,
+                  }));
+                  // Force refresh
+                  this.display();
+              });
+      });
+
+    if (!this.plugin.options.enableViewModeOverride) {
+      return;
+    }
+
+    new Setting(this.containerEl)
+      .setName("Default view for new note:")
+      .setDesc("The default view that a new calendar note gets opened in")
+      .addDropdown((dropdown) => {
+        dropdown.addOption("preview", `Reading view`);
+        dropdown.addOption("source", `Editing view`);
+        dropdown.setValue(this.plugin.options.viewModeOverride);
+        dropdown.onChange(async (value) => {
+          this.plugin.writeOptions(() => ({
+            viewModeOverride: value,
           }));
         });
       });


### PR DESCRIPTION
Provides a toggle-able dropdown to override Obsidian's view mode for new notes that are created via clicking on the calendar.
As requested by #196 