### PR TITLE
Change icon to calendar-days

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -78,7 +78,7 @@ export default class CalendarView extends ItemView {
   }
 
   getIcon(): string {
-    return "calendar-with-checkmark";
+    return "calendar-days";
   }
 
   onClose(): Promise<void> {


### PR DESCRIPTION
This better distinguishes this plugin from other calendar-related plugins like Day Planner, and is more representative of the purpose of the plugin.

It seems to be the best candidate out of all of the Lucide icons: https://lucide.dev/icons/?search=calendar